### PR TITLE
fixed reading/writing logic and aggregation

### DIFF
--- a/bom_automator.py
+++ b/bom_automator.py
@@ -1,6 +1,7 @@
 import csv
 import sys
 import distributor_cart as dc
+import readline
 
 class BomAutomator:
 	def __init__(self):
@@ -22,7 +23,7 @@ class BomAutomator:
 			reader = csv.reader(f)
 			colNames = next(reader) # don't need to keep first row
 			for row in reader:
-				self.board_qty[row[0]] = int(row[1])
+				self.board_qty[row[0].lower()] = int(row[1])
 
 	def process_board(self, csv_file):
 		"""
@@ -32,8 +33,11 @@ class BomAutomator:
 		Note that a board's bom marts parts from a variety of distributors.
 		"""
 		# Track current board name for later aggregation
-		currBoard = csv_file.replace("_", " ");
-		currBoard = currBoard[0 : len(currBoard) - 4]; # truncate the .csv part
+		currBoard = csv_file.replace("_", " ").lower();
+		if (currBoard[len(currBoard) - 3:] != "csv"):
+			print("%s is not a csv file." % currBoard)
+			return
+		currBoard = currBoard[0 : len(currBoard) - 4] # truncate the .csv part
 
 		# Read file
 		with open(csv_file, 'rt', encoding = 'ISO-8859-1') as f:
@@ -63,14 +67,15 @@ class BomAutomator:
 				else:
 					dCart_order_qty[partNum] += 1 * self.board_qty[currBoard]
 
-def main(args):
+def main(str):
 	auto = BomAutomator()
+	files = str.split() # default delimiter is space
 	# Read in command-line arguments
-	for file in args[1:]:
+	for file in files:
 		if file == "board_qty.csv": # Need to initialize board_qty first befoe processing any board
 			auto.init_board_qty(file)
 	
-	for file in args[1:]:
+	for file in files:
 		if file != "board_qty.csv":
 			auto.process_board(file) # Create distributorCart object for each board
 	
@@ -89,7 +94,12 @@ if __name__ == '__main__':
 	- use DistributorCart methods to output a csv representing each distributor_cart
 
 	"""
-	main(sys.argv)
+	print("Please pass in your board files and board quantity file following these instructions:")
+	print("\tAll files should be in the same directory, so you can pass in a file as 'boardName.csv', instead of 'anotherDir/boardName.csv'")
+	print("\tThe file containing board quantity is titled 'board_qty.csv'.")
+	print("\tThe board files are titled 'boardName.csv', with spaces replaced with underscore, e.g. 'Battery_Buzzer.csv'")
+	s = input("Please input your files: ")
+	main(s)
 
 
 

--- a/bom_automator.py
+++ b/bom_automator.py
@@ -33,7 +33,7 @@ class BomAutomator:
 		"""
 		# Track current board name for later aggregation
 		currBoard = csv_file.replace("_", " ");
-		currBoard = currBoard[0 : len(currBoard) - 4];
+		currBoard = currBoard[0 : len(currBoard) - 4]; # truncate the .csv part
 
 		# Read file
 		with open(csv_file, 'rt', encoding = 'ISO-8859-1') as f:

--- a/distributor_cart.py
+++ b/distributor_cart.py
@@ -39,8 +39,7 @@ class DistributorCart:
 		part_number = str(part_number)
 		url = "";
 		if name not in self.distributor_urls.keys():
-			print(name)
-			sys.exit("Currently cannot generate URL for distributor")
+			sys.exit("We currently cannot generate URL for %s" % name)
 		else:
 			if name == "sparkfun":
 				part_number = part_number[4:].strip("0") # need to strip the 0s for URL

--- a/distributor_cart.py
+++ b/distributor_cart.py
@@ -43,7 +43,7 @@ class DistributorCart:
 			sys.exit("Currently cannot generate URL for distributor")
 		else:
 			if name == "sparkfun":
-				part_number = part_number[4:].strip("0")
+				part_number = part_number[4:].strip("0") # need to strip the 0s for URL
 			distributor = self.distributor_urls[name]
 			url = distributor[0] + part_number + distributor[1]
 		return "%s" % (url)


### PR DESCRIPTION
Fixed process_board and bom_automator:

Added aggregation, initially forgot to consider the board quantities. Some bugs after the commit with just the aggregation: I realized that my previous code could potentially read a board file before first initializing board_qty dictionary, which would cause an error when trying to process the board file. I fixed this by implementing two for loops - the first for extracting board_qty.csv first, then the second for reading all the board files. Additionally, I added a lineterminator argument for the csv writer constructor in generate_part_number_csv and generate_url_csv to get rid of the extra rows in the outputted csv files.
